### PR TITLE
Fix native popup not showing

### DIFF
--- a/css/marketplace_info.css
+++ b/css/marketplace_info.css
@@ -3,8 +3,10 @@ body .marketplace-table {
 }
 
 .marketplace-table-cell-div {
-    display: inline;
+    display: flex;
     padding-top: 0;
+    flex-direction: column;
+    height: auto;
 }
 
 .marketplace-offer-low {


### PR DESCRIPTION
`display: inline;` messed with item popups in the market

Fixed version:

![grafik](https://user-images.githubusercontent.com/39794212/180638929-1783db6c-c87b-42a4-afbe-44ed9d67d312.png)
