### PR TITLE
Fix/Farming level not found results in inactive farming tracker

### DIFF
--- a/farming_tracker.js
+++ b/farming_tracker.js
@@ -125,15 +125,43 @@ class FarmingTracker {
     }
 
     getFarmingLevel() {
-        const sidebarFarming = document.getElementById('farmingHeaderundefined');
-        if (sidebarFarming.parentNode.getElementsByClassName("mastery-bar")[0]) {
-            return 99;
+        // Dael's script attaches the farming level to window 
+        if (window.ISState) {
+            return window.ISstate.skills.farming.level;
         }
-        return parseInt(sidebarFarming.previousElementSibling.innerText);
+        // If the user activated levels in the sidebar, the farming level is always accessible from there
+        const sidebarFarming = document.getElementById('farmingHeaderundefined');
+        if (sidebarFarming) {
+            if (sidebarFarming.parentNode.getElementsByClassName("mastery-bar")[0]) {
+                return 99;
+            }
+            return parseInt(sidebarFarming.previousElementSibling.innerText);
+        }
+        // Last option is the header, which might not be shown if the window is in half screen mode
+        const header = document.getElementById('farmingHeader');
+        if (header) {
+            if (header.previousSibling.firstChild.classList.contains('standard-levels-maxed')) {
+                return 99;
+            }
+            return parseInt(header.previousSibling.firstChild.lastChild.innerText);
+        }
+        // Fallback
+        return 99;
     }
 
     getEffectiveFarmingLevel() {
-        const sidebarFarming = document.getElementById('farmingHeaderundefined').getElementsByTagName("span")[1].innerHTML;
-        return parseInt(sidebarFarming.replace(/[^0-9]/g, ""));
+        if (window.ISState) {
+            return window.ISstate.skills.farming.masteryLevel;
+        }
+        const sidebarFarming = document.getElementById('farmingHeaderundefined');
+        if (sidebarFarming) {
+            return parseInt(sidebarFarming.getElementsByTagName("span")[1].innerHTML.replace(/[^0-9]/g, ""));
+        }
+        const header = document.getElementById('farmingHeader');
+        if (header) {
+            return document.getElementById('farmingHeader').childNodes[3].lastChild.textContent;
+        }
+        // Fallback
+        return this.getFarmingLevel();
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Idlescape Marketplace Tracker",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Automatically tracks prices of items on the Idlescape Marketplace",
     "content_scripts": [
         {

--- a/marketplace_tracker.user.js
+++ b/marketplace_tracker.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Idlescape Marketplace Tracker
 // @namespace    https://github.com/IceFreez3r
-// @version      1.0.2
+// @version      1.0.3
 // @description  Automatically tracks prices of items on the Idlescape Marketplace
 // @author       IceFreez3r
 // @match        *://*.idlescape.com/*


### PR DESCRIPTION
I falsely assumed, that you could always access the farming level through the sidebar. Turns out this is only true, if the user activated the level display there. To prevent this I added multiple options to retrieve the level:
- Dael's script attaches a state variable to the window, which also contains the farming level
- It can also be scraped from the header, if that's visible
- And if nothing works, I just assume that it's 99