### PR TITLE
Relative absolute api url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
     "content_scripts": [
         {
             "matches": [
-                "https://idlescape.com/game"
+                "https://idlescape.com/game",
+                "https://www.idlescape.com/game"
             ],
             "js": [
                 "modules/crafting.js",

--- a/marketplace_tracker.user.js
+++ b/marketplace_tracker.user.js
@@ -4,7 +4,7 @@
 // @version      1.0.5
 // @description  Automatically tracks prices of items on the Idlescape Marketplace
 // @author       IceFreez3r
-// @match        *://*.idlescape.com/*
+// @match        https://*.idlescape.com/game
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=idlescape.com
 // @updateURL    https://raw.githubusercontent.com/IceFreez3r/marketplace-tracker/main/marketplace_tracker.user.js
 // @downloadURL  https://raw.githubusercontent.com/IceFreez3r/marketplace-tracker/main/marketplace_tracker.user.js

--- a/storage.js
+++ b/storage.js
@@ -190,7 +190,8 @@ function addHardcodedItems() {
 }
 
 function fetchAPI() {
-    fetch("https://idlescape.com/api/market/manifest")
+    const apiUrl = window.location.origin + "/api/market/manifest";
+    fetch(apiUrl)
         .then(function (response) {
             return response.json();
         })


### PR DESCRIPTION
API URL now also works at `https://www.idlescape.com/game` (with the `www`)