### PR TITLE
v1.1.7, Crafting Tracker, synced api, onAPIUpdate, fixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ tracker.addModule(MarketHighlights);
 tracker.addModule(OfflineTracker);
 tracker.addModule(EnchantingTracker);
 tracker.addModule(SmithingTracker);
-// tracker.addModule(CraftingTracker);
+tracker.addModule(CraftingTracker);
 tracker.addModule(RunecraftingTracker);
 tracker.addModule(FarmingTracker);
 tracker.addModule(AlertTracker);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Idlescape Marketplace Tracker",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "description": "Automatically tracks prices of items on the Idlescape Marketplace",
     "content_scripts": [
         {

--- a/marketplace_tracker.user.js
+++ b/marketplace_tracker.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Idlescape Marketplace Tracker
 // @namespace    https://github.com/IceFreez3r
-// @version      1.1.6
+// @version      1.1.7
 // @description  Automatically tracks prices of items on the Idlescape Marketplace
 // @author       IceFreez3r
 // @match        https://www.play.idlescape.com/*
@@ -35,7 +35,7 @@
     tracker.addModule(OfflineTracker);
     tracker.addModule(EnchantingTracker);
     tracker.addModule(SmithingTracker);
-    // tracker.addModule(CraftingTracker);
+    tracker.addModule(CraftingTracker);
     tracker.addModule(RunecraftingTracker);
     tracker.addModule(FarmingTracker);
     tracker.addModule(AlertTracker);

--- a/modules/alert.js
+++ b/modules/alert.js
@@ -341,8 +341,8 @@ class AlertTracker {
             priceBelowInput.value = "";
             priceAboveInput.value = "";
         } else {
-            priceBelowInput.value = this.allAlerts[itemId].below;
-            priceAboveInput.value = this.allAlerts[itemId].above;
+            priceBelowInput.value = this.allAlerts[itemId].below ?? undefined;
+            priceAboveInput.value = this.allAlerts[itemId].above ?? undefined;
         }
 
         document.getElementsByClassName("save")[0].addEventListener("click", () => {
@@ -370,10 +370,13 @@ class AlertTracker {
         if ((priceBelow === 0 || priceBelow === "") && (priceAbove === 0 || priceAbove === "")) {
             delete this.allAlerts[itemId];
         } else {
-            this.allAlerts[itemId] = {
-                below: priceBelow,
-                above: priceAbove,
-            };
+            this.allAlerts[itemId] = {};
+            if (priceBelow !== 0 && priceBelow !== "") {
+                this.allAlerts[itemId].below = priceBelow;
+            }
+            if (priceAbove !== 0 && priceAbove !== "") {
+                this.allAlerts[itemId].above = priceAbove;
+            }
         }
         const alertButton = document.getElementById("marketplace-alert-button");
         alertButton.classList.toggle("svg-inactive", !this.hasActiveAlert(itemId));

--- a/modules/alert.js
+++ b/modules/alert.js
@@ -341,8 +341,8 @@ class AlertTracker {
             priceBelowInput.value = "";
             priceAboveInput.value = "";
         } else {
-            priceBelowInput.value = this.allAlerts[itemId].below ?? undefined;
-            priceAboveInput.value = this.allAlerts[itemId].above ?? undefined;
+            priceBelowInput.value = this.allAlerts[itemId].below;
+            priceAboveInput.value = this.allAlerts[itemId].above;
         }
 
         document.getElementsByClassName("save")[0].addEventListener("click", () => {

--- a/modules/crafting.js
+++ b/modules/crafting.js
@@ -4,6 +4,10 @@ class CraftingTracker {
     static icon = "<img src='images/ui/crafting_icon.png' alt='Crafting Tracker Icon'/>";
     static category = "recipe";
     css = `
+.crafting-container {
+    grid-template-rows: 1fr max-content;
+}
+
 .crafting-info-table {
     grid-column: span 2;
     display: grid; /* Grid Layout specified by js */

--- a/modules/crafting.js
+++ b/modules/crafting.js
@@ -134,7 +134,10 @@ class CraftingTracker {
             return;
         }
         const craftedItemIcon = recipeNode.getElementsByClassName("crafting-item-icon")[0].getElementsByTagName("img")[0].src;
-        const craftedItemId = convertItemId(craftedItemIcon);
+        let craftedItemId = convertItemId(craftedItemIcon);
+        if (this.storage.itemRequiresFallback(craftedItemId)) {
+            craftedItemId = recipeNode.getElementsByClassName("crafting-item-name")[0].innerText;
+        }
         // prevent repeated calls
         if (!forceUpdate && craftedItemId === this.lastCraftedItemId) {
             // for items with multiple recipes

--- a/modules/crafting.js
+++ b/modules/crafting.js
@@ -1,26 +1,14 @@
 class CraftingTracker {
-    static id = "crafting_tracker"
+    static id = "crafting_tracker";
     static displayName = "Crafting Tracker";
     static icon = "<img src='images/ui/crafting_icon.png' alt='Crafting Tracker Icon'/>";
     static category = "recipe";
     css = `
-.crafting-item-container {
-    display: flex;
-    flex-direction: column;
-}
-
-body .crafting-container {
-    height: auto;
-    flex: 1 0 auto;
-}
-
 .crafting-info-table {
+    grid-column: span 2;
     display: grid; /* Grid Layout specified by js */
     grid-gap: 5px;
-    /* combination of rgba(36, 36, 36, .671) in front of rgba(0, 0, 0, .705) */
-    background: rgba(24.156, 24.156, 24.156, .902945);
-    border: 2px solid gray;
-    padding: 6px;
+    padding: 15px 20px;
     margin-top: 6px;
     border-radius: 6px;
     place-items: center;
@@ -70,13 +58,8 @@ body .crafting-container {
         this.lastCraftedItemId = null;
         this.lastSelectedNavTab = null;
 
-        this.playAreaObserver = new MutationObserver(mutations => {
-            if (getSelectedSkill() === "Crafting") {
-                if (detectInfiniteLoop(mutations)) {
-                    return;
-                }
-                this.craftingTracker();
-            }
+        this.playAreaObserver = new MutationObserver((mutations) => {
+            this.checkForCrafting(mutations);
         });
     }
 
@@ -84,7 +67,7 @@ body .crafting-container {
         const playAreaContainer = document.getElementsByClassName("play-area-container")[0];
         this.playAreaObserver.observe(playAreaContainer, {
             attributes: true,
-            attributeFilter: ['src'],
+            attributeFilter: ["src"],
             childList: true,
             subtree: true,
         });
@@ -96,17 +79,26 @@ body .crafting-container {
     }
 
     settingsMenuContent() {
-        let moduleSetting = document.createElement('div');
-        moduleSetting.classList.add('tracker-module-setting');
-        moduleSetting.insertAdjacentHTML('beforeend',`
+        let moduleSetting = document.createElement("div");
+        moduleSetting.classList.add("tracker-module-setting");
+        moduleSetting.insertAdjacentHTML(
+            "beforeend",
+            `
             <div class="tracker-module-setting-name">
                 Profit
-            </div>`);
-        moduleSetting.append(Templates.selectMenu(CraftingTracker.id + "-profit", {
-                off: "Off",
-                percent: "Percent",
-                flat: "Flat",
-            }, this.settings.profit));
+            </div>`
+        );
+        moduleSetting.append(
+            Templates.selectMenu(
+                CraftingTracker.id + "-profit",
+                {
+                    off: "Off",
+                    percent: "Percent",
+                    flat: "Flat",
+                },
+                this.settings.profit
+            )
+        );
 
         const goldPerXP = `
             <div class="tracker-module-setting">
@@ -123,19 +115,28 @@ body .crafting-container {
     }
 
     onAPIUpdate() {
-        return;
+        this.checkForCrafting(null, true);
     }
 
-    craftingTracker(){
+    checkForCrafting(mutations, forceUpdate = false) {
+        if (getSelectedSkill() === "Crafting") {
+            if (mutations && detectInfiniteLoop(mutations)) {
+                return;
+            }
+            this.craftingTracker(forceUpdate);
+        }
+    }
+
+    craftingTracker(forceUpdate = false) {
         let recipeNode = document.getElementsByClassName("crafting-container")[0];
         if (!recipeNode) {
             this.lastCraftedItemId = null;
             return;
         }
-        const craftedItemId = convertItemId(recipeNode.getElementsByClassName("crafting-item-icon")[0].firstChild.src);
-        let craftingAmount = 1;
+        const craftedItemIcon = recipeNode.getElementsByClassName("crafting-item-icon")[0].getElementsByTagName("img")[0].src;
+        const craftedItemId = convertItemId(craftedItemIcon);
         // prevent repeated calls
-        if (craftedItemId === this.lastCraftedItemId) {
+        if (!forceUpdate && craftedItemId === this.lastCraftedItemId) {
             // for items with multiple recipes
             const selectedNavTab = recipeNode.getElementsByClassName("selected-tab")[0];
             if (!selectedNavTab) {
@@ -145,19 +146,9 @@ body .crafting-container {
                 return;
             }
             this.lastSelectedNavTab = selectedNavTab.innerText;
-            // amount of crafts might be higher than one when only switching recipes for the same item
-            craftingAmount = document.getElementById('craftCount').value;
         }
         this.lastCraftedItemId = craftedItemId;
-
-        const craftedItemIcon = recipeNode.getElementsByClassName("crafting-item-icon")[0].firstChild.src;
-        let craftedItemCount = 1;
-        // for recipes which result in more than one item (usually baits)
-        const description = recipeNode.getElementsByClassName('crafting-item-description')[0].innerText;
-        const regex = /(?<=Each craft results in )\d+/.exec(description);
-        if (regex !== null) {
-            craftedItemCount = parseInt(regex[0]);
-        }
+        const craftingAmount = parseInt(document.querySelector(".crafting-item-icon > .centered")?.textContent) || 1;
 
         const resourceItemNodes = recipeNode.getElementsByClassName("crafting-item-resource");
         let resourceItemIds = [];
@@ -165,43 +156,47 @@ body .crafting-container {
         let resourceItemCounts = [];
         for (let i = 0; i < resourceItemNodes.length; i++) {
             let resourceItemId = convertItemId(resourceItemNodes[i].childNodes[1].src);
-            if (resourceItemId.includes('essence')) {
-                continue;
-            }
             resourceItemIds.push(resourceItemId);
             resourceItemIcons.push(resourceItemNodes[i].childNodes[1].src);
             resourceItemCounts.push(parseNumberString(resourceItemNodes[i].firstChild.textContent) / craftingAmount);
         }
 
-        const recipePrices = this.storage.handleRecipe(resourceItemIds, craftedItemId)
+        const recipePrices = this.storage.handleRecipe(resourceItemIds, craftedItemId);
         // TODO: use vendor price where appropriate
 
         // crafting info table
         document.getElementsByClassName("crafting-info-table")[0]?.remove();
-        let craftingContainer = document.getElementsByClassName("crafting-item-container")[0];
-        const ingredients = Object.assign(recipePrices.ingredients, {icons: resourceItemIcons, counts: resourceItemCounts});
-        const product = Object.assign(recipePrices.product, {icon: craftedItemIcon, count: craftedItemCount});
-        saveInsertAdjacentHTML(craftingContainer, 'beforeend', Templates.infoTableTemplate('crafting', ingredients, product, this.settings.profit));
-        
+        const craftingContainer = document.getElementsByClassName("crafting-container")[0];
+        const ingredients = Object.assign(recipePrices.ingredients, { icons: resourceItemIcons, counts: resourceItemCounts });
+        const product = Object.assign(recipePrices.product, { icon: craftedItemIcon, count: craftingAmount });
+        saveInsertAdjacentHTML(
+            craftingContainer,
+            "beforeend",
+            Templates.infoTableTemplate("crafting", ingredients, product, this.settings.profit, false, false, undefined, undefined, "idlescape-container")
+        );
+
         if (this.settings.goldPerXP) {
             this.goldPerXP(recipeNode, ingredients, product, resourceItemCounts);
         }
     }
-    
+
     goldPerXP(recipeNode, ingredients, product, resourceItemCounts) {
-        document.getElementsByClassName('crafting-gold-per-exp')[0]?.remove();
+        document.getElementsByClassName("crafting-gold-per-exp")[0]?.remove();
         const experienceNode = recipeNode.getElementsByClassName("crafting-item-exp small")[0];
         const experience = parseNumberString(experienceNode.childNodes[0].textContent);
         if (experience === 0) {
             return;
         }
-        let minCost = - profit('flat', totalRecipePrice(ingredients.minPrices, resourceItemCounts), product.minPrice * product.count);
-        let maxCost = - profit('flat', totalRecipePrice(ingredients.maxPrices, resourceItemCounts), product.maxPrice * product.count);
+        let minCost = -profit("flat", totalRecipePrice(ingredients.minPrices, resourceItemCounts), product.minPrice * product.count);
+        let maxCost = -profit("flat", totalRecipePrice(ingredients.maxPrices, resourceItemCounts), product.maxPrice * product.count);
         // swap min and max if min is higher than max
         if (minCost > maxCost) {
             [minCost, maxCost] = [maxCost, minCost];
         }
-        saveInsertAdjacentHTML(experienceNode, 'afterend', `
+        saveInsertAdjacentHTML(
+            experienceNode,
+            "afterend",
+            `
             <div class="crafting-gold-per-exp">
                 <span>
                     ${formatNumber(minCost / experience, true)} ~ ${formatNumber(maxCost / experience, true)}
@@ -209,6 +204,7 @@ body .crafting-container {
                 <img class="crafting-gold-per-exp-icon" src="/images/money_icon.png">
                 <span>/</span>
                 <img class="crafting-gold-per-exp-icon" src="/images/total_level.png">
-            </div>`);
+            </div>`
+        );
     }
 }

--- a/modules/enchanting.js
+++ b/modules/enchanting.js
@@ -53,15 +53,10 @@ body .scrollcrafting-container {
         this.cssNode = injectCSS(this.css);
 
         this.playAreaObserver = new MutationObserver(mutations => {
-            if (getSelectedSkill() === "Enchanting" && this.selectedTab() === "Scrollcrafting") {
-                if (detectInfiniteLoop(mutations)) {
-                    return;
-                }
-                this.enchantingTracker();
-            }
+            this.checkForEnchanting(mutations);
         });
     }
-    
+
     onGameReady() {
         const playAreaContainer = document.getElementsByClassName("play-area-container")[0];
         this.playAreaObserver.observe(playAreaContainer, {
@@ -96,7 +91,16 @@ body .scrollcrafting-container {
     }
 
     onAPIUpdate() {
-        return;
+        this.checkForEnchanting();
+    }
+
+    checkForEnchanting(mutations) {
+        if (getSelectedSkill() === "Enchanting" && this.selectedTab() === "Scrollcrafting") {
+            if (mutations && detectInfiniteLoop(mutations)) {
+                return;
+            }
+            this.enchantingTracker();
+        }
     }
 
     enchantingTracker() {
@@ -107,10 +111,7 @@ body .scrollcrafting-container {
     }
 
     processEnchantment(recipe) {
-        // Table already exists
-        if (recipe.getElementsByClassName("enchanting-info-table")[0]) {
-            return;
-        }
+        recipe.getElementsByClassName("enchanting-info-table")[0]?.remove();
         const scrollId = convertItemId(recipe.firstChild.src);
         const scrollIcon = recipe.firstChild.src;
 

--- a/modules/enchanting.js
+++ b/modules/enchanting.js
@@ -53,16 +53,14 @@ body .scrollcrafting-container {
         this.cssNode = injectCSS(this.css);
 
         this.playAreaObserver = new MutationObserver(mutations => {
+            this.playAreaObserver.disconnect();
             this.checkForEnchanting(mutations);
+            this.connectPlayAreaObserver();
         });
     }
 
     onGameReady() {
-        const playAreaContainer = document.getElementsByClassName("play-area-container")[0];
-        this.playAreaObserver.observe(playAreaContainer, {
-            childList: true,
-            subtree: true
-        });
+        this.connectPlayAreaObserver();
     }
 
     deactivate() {
@@ -94,6 +92,14 @@ body .scrollcrafting-container {
         this.checkForEnchanting();
     }
 
+    connectPlayAreaObserver() {
+        const playAreaContainer = document.getElementsByClassName("play-area-container")[0];
+        this.playAreaObserver.observe(playAreaContainer, {
+            childList: true,
+            subtree: true
+        });
+    }
+
     checkForEnchanting(mutations) {
         if (getSelectedSkill() === "Enchanting" && this.selectedTab() === "Scrollcrafting") {
             if (mutations && detectInfiniteLoop(mutations)) {
@@ -112,13 +118,17 @@ body .scrollcrafting-container {
 
     processEnchantment(recipe) {
         recipe.getElementsByClassName("enchanting-info-table")[0]?.remove();
-        const scrollId = convertItemId(recipe.firstChild.src);
+        let scrollId = convertItemId(recipe.firstChild.src);
+        if (this.storage.itemRequiresFallback(scrollId)) {
+            scrollId = recipe.childNodes[1].innerText;
+        }
         const scrollIcon = recipe.firstChild.src;
 
         let standardResources = this.getStandardResources(recipe.getElementsByClassName("scrollcrafting-standard-resources")[0]);
         let dynamicResources = this.getDynamicResources(recipe.getElementsByClassName("scrollcrafting-dynamic-resources")[0]);
         // combine lists of objects into separate lists
-        let resourceItemIds = ["scroll"].concat(dynamicResources.map(resource => resource.itemId));
+        // "Scroll" is the fallback item id for the scroll, some ability books also use the same icon
+        let resourceItemIds = ["Scroll"].concat(dynamicResources.map(resource => resource.itemId));
         let resourceItemIcons = ["/images/enchanting/scroll.png"].concat(dynamicResources.map(resource => resource.icon));
         let resourceItemCounts = [standardResources.scrolls].concat(dynamicResources.map(resource => resource.amount));
         const recipePrices = this.storage.handleRecipe(resourceItemIds, scrollId);

--- a/modules/highlight.js
+++ b/modules/highlight.js
@@ -160,15 +160,7 @@ class MarketHighlights {
         this.notificationInformation = {}; // comes from alert.js
 
         this.playAreaObserver = new MutationObserver((mutations) => {
-            if (getSelectedSkill() === "Marketplace") {
-                if (detectInfiniteLoop(mutations)) {
-                    return;
-                }
-                this.highlight();
-            } else {
-                this.favoriteFilterActive = false;
-                this.quantileColorsActive = false;
-            }
+            this.checkForMarketplace(mutations);
         });
     }
 
@@ -236,13 +228,25 @@ class MarketHighlights {
     }
 
     onAPIUpdate() {
-        return;
+        this.checkForMarketplace();
     }
 
     onNotify(message, data) {
         if (message === "alerts") {
             this.notificationInformation = data;
-            this.onAPIUpdate();
+            this.checkForMarketplace();
+        }
+    }
+
+    checkForMarketplace(mutations) {
+        if (getSelectedSkill() === "Marketplace") {
+            if (mutations && detectInfiniteLoop(mutations)) {
+                return;
+            }
+            this.highlight();
+        } else {
+            this.favoriteFilterActive = false;
+            this.quantileColorsActive = false;
         }
     }
 

--- a/modules/marketplace.js
+++ b/modules/marketplace.js
@@ -223,8 +223,8 @@ class MarketplaceTracker {
     checkForMarketplace(mutations) {
         if (getSelectedSkill() === "Marketplace") {
             if (mutations && detectInfiniteLoop(mutations)) {
-        return;
-    }
+                return;
+            }
             this.marketplaceTracker();
         }
     }
@@ -252,8 +252,8 @@ class MarketplaceTracker {
         const itemId = convertItemId(offers[0].childNodes[1].firstChild.src);
         const analysis = this.storage.analyzeItem(itemId);
         document.getElementsByClassName("marketplace-analysis-table")[0]?.remove();
-            const marketplaceTop = document.getElementsByClassName("marketplace-buy-item-top")[0];
-            saveInsertAdjacentHTML(marketplaceTop, "afterend", this.priceAnalysisTableTemplate(analysis));
+        const marketplaceTop = document.getElementsByClassName("marketplace-buy-item-top")[0];
+        saveInsertAdjacentHTML(marketplaceTop, "afterend", this.priceAnalysisTableTemplate(analysis));
         this.markOffers(offers, analysis.maxPrice);
         // this.priceHoverListener(offers, analysis.maxPrice); // TODO
     }
@@ -492,10 +492,15 @@ class MarketplaceTracker {
         const vendorPriceString = document.getElementById("lowest-price-npc").textContent.replace("Item sells to NPCs for:", "").replaceAll(" ", "");
         const vendorPrice = parseNumberString(vendorPriceString);
         const priceInput = document.getElementsByClassName("anchor-sell-price-input")[0];
+        this.checkPrice(warningIcon, priceInput, vendorPrice);
         priceInput.addEventListener("input", () => {
-            const price = parseCompactNumberString(priceInput.value);
-            const tooLowPrice = Math.floor(price * 0.95) < vendorPrice;
-            warningIcon.classList.toggle("hidden", !tooLowPrice);
+            this.checkPrice(warningIcon, priceInput, vendorPrice);
         });
+    }
+
+    checkPrice(warningIcon, priceInput, vendorPrice) {
+        const price = parseCompactNumberString(priceInput.value);
+        const tooLowPrice = Math.floor(price * 0.95) < vendorPrice;
+        warningIcon.classList.toggle("hidden", !tooLowPrice);
     }
 }

--- a/modules/marketplace.js
+++ b/modules/marketplace.js
@@ -154,12 +154,7 @@ class MarketplaceTracker {
         this.lastHistoryPage = 0;
 
         this.playAreaObserver = new MutationObserver((mutations) => {
-            if (getSelectedSkill() === "Marketplace") {
-                if (detectInfiniteLoop(mutations)) {
-                    return;
-                }
-                this.marketplaceTracker();
-            }
+            this.checkForMarketplace(mutations);
         });
         this.sellDialogChecker = new MutationObserver((mutations) => {
             if (document.getElementById("lowest-price")) {
@@ -222,7 +217,16 @@ class MarketplaceTracker {
     }
 
     onAPIUpdate() {
+        this.checkForMarketplace();
+    }
+
+    checkForMarketplace(mutations) {
+        if (getSelectedSkill() === "Marketplace") {
+            if (mutations && detectInfiniteLoop(mutations)) {
         return;
+    }
+            this.marketplaceTracker();
+        }
     }
 
     marketplaceTracker() {
@@ -247,10 +251,9 @@ class MarketplaceTracker {
         }
         const itemId = convertItemId(offers[0].childNodes[1].firstChild.src);
         const analysis = this.storage.analyzeItem(itemId);
-        if (document.getElementsByClassName("marketplace-analysis-table").length === 0) {
+        document.getElementsByClassName("marketplace-analysis-table")[0]?.remove();
             const marketplaceTop = document.getElementsByClassName("marketplace-buy-item-top")[0];
             saveInsertAdjacentHTML(marketplaceTop, "afterend", this.priceAnalysisTableTemplate(analysis));
-        }
         this.markOffers(offers, analysis.maxPrice);
         // this.priceHoverListener(offers, analysis.maxPrice); // TODO
     }
@@ -280,11 +283,9 @@ class MarketplaceTracker {
     }
 
     markOffers(offers, maxPrice) {
-        for (let i = 0; i < offers.length; i++) {
-            let offer = offers[i];
+        for (const offer of offers) {
             offer.classList.remove("marketplace-offer-low", "marketplace-offer-medium", "marketplace-offer-high");
-            let offerPrice = offer.childNodes[3].innerText;
-            offerPrice = parseNumberString(offerPrice);
+            const offerPrice = parseNumberString(offer.childNodes[3].innerText);
             if (offerPrice < maxPrice * 0.6) {
                 offer.classList.add("marketplace-offer-low");
             } else if (offerPrice < maxPrice * 0.8) {

--- a/modules/offline.js
+++ b/modules/offline.js
@@ -89,7 +89,7 @@ class OfflineTracker {
     }
 
     onAPIUpdate() {
-        return;
+        this.offlineTracker();
     }
 
     offlineTracker(){

--- a/modules/runecrafting.js
+++ b/modules/runecrafting.js
@@ -70,16 +70,14 @@ body .runecrafting-essence-counter {
         this.cssNode = injectCSS(this.css);
 
         this.playAreaObserver = new MutationObserver(mutations => {
+            this.playAreaObserver.disconnect();
             this.checkForRunecrafting(mutations);
+            this.connectPlayAreaObserver();
         });
     }
 
     onGameReady() {
-        const playAreaContainer = document.getElementsByClassName("play-area-container")[0];
-        this.playAreaObserver.observe(playAreaContainer, {
-            childList: true,
-            subtree: true,
-        });
+        this.connectPlayAreaObserver();
     }
 
     deactivate() {
@@ -109,6 +107,14 @@ body .runecrafting-essence-counter {
 
     onAPIUpdate() {
         this.checkForRunecrafting();
+    }
+
+    connectPlayAreaObserver() {
+        const playAreaContainer = document.getElementsByClassName("play-area-container")[0];
+        this.playAreaObserver.observe(playAreaContainer, {
+            childList: true,
+            subtree: true,
+        });
     }
 
     checkForRunecrafting(mutations) {

--- a/modules/runecrafting.js
+++ b/modules/runecrafting.js
@@ -55,7 +55,7 @@ body .runecrafting-essence-counter {
 
 .runecrafting-info-table-font {
     font-size: 1.5rem;
-    line-height: 2rem;    
+    line-height: 2rem;
 }
 
     `;
@@ -70,12 +70,7 @@ body .runecrafting-essence-counter {
         this.cssNode = injectCSS(this.css);
 
         this.playAreaObserver = new MutationObserver(mutations => {
-            if (getSelectedSkill() === "Runecrafting") {
-                if (detectInfiniteLoop(mutations)) {
-                    return;
-                }
-                this.runecraftingTracker();
-            }
+            this.checkForRunecrafting(mutations);
         });
     }
 
@@ -113,7 +108,16 @@ body .runecrafting-essence-counter {
     }
 
     onAPIUpdate() {
-        return;
+        this.checkForRunecrafting();
+    }
+
+    checkForRunecrafting(mutations) {
+        if (getSelectedSkill() === "Runecrafting") {
+            if (mutations && detectInfiniteLoop(mutations)) {
+                return;
+            }
+            this.runecraftingTracker();
+        }
     }
 
     runecraftingTracker() {
@@ -133,9 +137,7 @@ body .runecrafting-essence-counter {
     }
 
     processRecipe(recipe, activeTab, activeTalisman) {
-        if (recipe.getElementsByClassName("runecrafting-info-table")[0]) {
-            return;
-        }
+        recipe.getElementsByClassName("runecrafting-info-table")[0]?.remove();
 
         const productId = convertItemId(recipe.getElementsByClassName("resource-as-row-image")[0].src);
         const productIcon = recipe.getElementsByClassName("resource-as-row-image")[0].src;

--- a/storage.js
+++ b/storage.js
@@ -22,7 +22,7 @@ class Storage {
                     // Add fallback for itemImages that are used by multiple items
                     this.idMap[vanillaItemsList[item].name] = item;
                     if (this.idMap[itemImage] !== -1) {
-                        this.idMap[vanillaItemsList[this.idMap[itemImage]].name] = item;
+                        this.idMap[vanillaItemsList[this.idMap[itemImage]].name] = this.idMap[itemImage];
                         // prevent getting the wrong item
                         this.idMap[itemImage] = -1;
                     }

--- a/storage.js
+++ b/storage.js
@@ -6,6 +6,7 @@ class Storage {
         this.latestPriceList = {};
 
         this.lastLogin = this.loadLocalStorage('lastLogin', Date.now());
+        this.latestAPIFetch = this.loadLocalStorage('TrackerLatestAPIFetch', 0);
     }
 
     async onGameReady() {
@@ -17,7 +18,17 @@ class Storage {
             };
             if (vanillaItemsList[item].itemImage) {
                 const itemImage = convertItemId(vanillaItemsList[item].itemImage);
-                this.idMap[itemImage] = item;
+                if (this.idMap[itemImage] !== undefined) {
+                    // Add fallback for itemImages that are used by multiple items
+                    this.idMap[vanillaItemsList[item].name] = item;
+                    if (this.idMap[itemImage] !== -1) {
+                        this.idMap[vanillaItemsList[this.idMap[itemImage]].name] = item;
+                        // prevent getting the wrong item
+                        this.idMap[itemImage] = -1;
+                    }
+                } else {
+                    this.idMap[itemImage] = item;
+                }
                 this.itemList[item].itemImage = itemImage;
             }
             if (vanillaItemsList[item].itemIcon) {
@@ -36,19 +47,28 @@ class Storage {
     }
 
     handleApiData(data) {
-        const timestamp = Math.floor(Date.now() / 1000 / 60 / 10);
+        const timestamp = Math.floor(new Date(data.timestamp).valueOf() / 1000 / 60 / 10);
         this.latestPriceList = {};
+        data = data.manifest;
         for (let i = 0; i < data.length; i++) {
             const apiId = data[i].itemID;
-            this.itemList[apiId]["prices"].push([timestamp, data[i].minPrice]);
-            this.sortPriceList(apiId);
+            if (this.latestAPIFetch !== timestamp) {
+                // prevent duplicate entries
+                this.itemList[apiId].prices.push([timestamp, data[i].minPrice]);
+                this.sortPriceList(apiId);
+            }
             this.latestPriceList[apiId] = data[i].minPrice;
         }
         const currentHeatValue = this.heatValue();
-        this.itemList[2]["prices"].push([timestamp, currentHeatValue.heatValue]);
-        this.sortPriceList(2);
+        if (this.latestAPIFetch !== timestamp) {
+            // prevent duplicate entries
+            this.itemList[2].prices.push([timestamp, currentHeatValue.heatValue]);
+            this.sortPriceList(2);
+            this.storeItemList();
+        }
         this.latestPriceList[2] = currentHeatValue.heatValue;
-        this.storeItemList();
+        this.latestAPIFetch = timestamp;
+        localStorage.setItem("TrackerLatestAPIFetch", timestamp);
     }
 
     bestHeatItem() {
@@ -101,7 +121,14 @@ class Storage {
 
     storeItemList() {
         this.itemList = sortObj(this.itemList);
-        localStorage.setItem('itemList', JSON.stringify(this.itemList));
+        // Reduce the size of the stored itemList by removing items that have no prices
+        const itemList = Object.keys(this.itemList).reduce((result, key) => {
+            if (this.itemList[key].prices.length > 0) {
+                result[key] = this.itemList[key];
+            }
+            return result;
+        }, {});
+        localStorage.setItem('itemList', JSON.stringify(itemList));
     }
 
     getItemName(itemId) {
@@ -109,7 +136,12 @@ class Storage {
             return null;
         }
         const apiId = this.idMap[itemId];
-        return this.itemList[apiId]["name"];
+        if (apiId === -1) return "Duplicate Item";
+        return this.itemList[apiId].name;
+    }
+
+    itemRequiresFallback(itemId) {
+        return !itemId in this.idMap || this.idMap[itemId] === -1;
     }
 
     analyzeItem(itemId) {
@@ -132,7 +164,7 @@ class Storage {
             };
         }
         const apiId = this.idMap[itemId];
-        if (this.itemList[apiId].prices.length === 0) {
+        if (apiId === -1 || this.itemList[apiId].prices.length === 0) {
             return {
                 minPrice: NaN,
                 medianPrice: NaN,
@@ -177,29 +209,31 @@ class Storage {
     }
 
     /**
+     * @param {Array} itemIdsWithFallbacks Array of itemIds or their fallback
      * @returns {Object} Object with pairs of itemIds and their latest price quantiles
      */
-    latestPriceQuantiles() {
-        return Object.keys(this.idMap).reduce((result, itemId) => {
+    latestPriceQuantiles(itemIdsWithFallbacks) {
+        const quantiles = [];
+        for (const itemId of itemIdsWithFallbacks) {
             const apiId = this.idMap[itemId];
-            if (this.itemList[apiId]["prices"].length <= 1) {
-                result[itemId] = 1;
-                return result;
+            if (apiId === -1 || this.itemList[apiId].prices.length <= 1) {
+                quantiles.push(1);
+                continue;
             }
-            const index = this.itemList[apiId]["prices"].findLastIndex((priceTuple) => priceTuple[1] === this.latestPriceList[apiId]);
+            const index = this.itemList[apiId].prices.findLastIndex((priceTuple) => priceTuple[1] === this.latestPriceList[apiId]);
             if (index === -1) {
-                result[itemId] = 1;
-                return result;
+                quantiles.push(1);
+                continue;
             }
-            const quantile = index / (this.itemList[apiId]["prices"].length - 1);
-            result[itemId] = quantile;
-            return result;
-        }, {});
+            const quantile = index / (this.itemList[apiId].prices.length - 1);
+            quantiles.push(quantile);
+        }
+        return quantiles;
     }
 
     sortPriceList(apiId) {
         // Sort the price tuples by price
-        this.itemList[apiId]["prices"].sort((a, b) => {
+        this.itemList[apiId].prices.sort((a, b) => {
             return a[1] - b[1];
         });
     }
@@ -227,7 +261,6 @@ class Storage {
                 // last api timestamp + 20 minutes - now
                 timeUntilNextUpdate = new Date(lastAPITimestamp).valueOf() + 1000 * 60 * 10 * 2 - Date.now();
             }
-            console.log("Time until the next fetch (in ms):", timeUntilNextUpdate);
             setTimeout(() => {
                 this.fetchAPILoop();
             }, timeUntilNextUpdate + 1000 * 10);
@@ -242,8 +275,7 @@ class Storage {
             })
             .then((data) => {
                 if (data.status === "Success") {
-                    this.handleApiData(data.manifest);
-                    console.log("API timestamp: ", data.timestamp);
+                    this.handleApiData(data);
                     return data.timestamp;
                 } else {
                     console.error("Error fetching API data. Status: " + data.status);

--- a/templates.js
+++ b/templates.js
@@ -26,7 +26,7 @@ class Templates {
 
     /**
      * Creates a checkbox template
-     * 
+     *
      * @param {string} id When saving settings the id gets split at all '-' and then saved in the settings menu at that position
      *                    e.g. a checkbox with id "module-css-header" will store `1` or `0` in `this.settings.module.css.header`.
      *                    The setting needs to be set to a default value in the constructor of the corresponding module if it's
@@ -63,14 +63,14 @@ class Templates {
                 <rect class="rect-first" x="12" y="38" width="50" height="50" rx="5" ry="5"/>
             </svg>`;
         }
-    
+
     static dotTemplate(size, classes = "", color = "hsl(40, 80%, 40%)") {
         return `
             <svg class="${classes}" viewbox="0 0 100 100" style="width: ${size}; height: ${size}; fill: ${color};">
                 <circle cx="50" cy="50" r="50"/>
             </svg>`;
     }
-    
+
     static favoriteTemplate(classes = "") {
         return `
             <svg class="${classes}" stroke="rgb(255,255,0)" stroke-width="30px" fill="rgb(255,255,0)" x="0px" y="0px" width="24px" heigth="24px" viewBox="-15 -10 366 366">
@@ -79,7 +79,7 @@ class Templates {
     }
 
     /**
-     * 
+     *
      * @param {string} classId used for css classes, `[classId]-info-table`, `[classId]-info-table-content`, `[classId]-info-table-icon` and `[classId]-info-table-font` can be used to style the table
      * @param {Object} ingredients icons, counts, minPrices and maxPrices as arrays of the ingredients
      * @param {Object} product icon, count, minPrice and maxPrice of the product
@@ -90,7 +90,7 @@ class Templates {
      * @param {Number=} chance chance to successfully craft the product
      * @returns {string} html string
      */
-    static infoTableTemplate(classId, ingredients, product, profitType, compactDisplay = false, showCounts = false, secondsPerAction = null, chance = 1) {
+    static infoTableTemplate(classId, ingredients, product, profitType, compactDisplay = false, showCounts = false, secondsPerAction = null, chance = 1, classes = "") {
         const { icons: ingredientIcons, counts: ingredientCounts, minPrices: ingredientMinPrices, maxPrices: ingredientMaxPrices } = ingredients;
         const { icon: productIcon, count: productCount, minPrice: productMinPrice, maxPrice: productMaxPrice } = product;
         // Ingredients
@@ -123,7 +123,7 @@ class Templates {
         const minPrice = Templates.infoTableRow(classId, ingredientMinPrices, ingredientCounts, productMinPrice, productCount, profitType, compactDisplay, secondsPerAction, chance);
         const maxPrice = Templates.infoTableRow(classId, ingredientMaxPrices, ingredientCounts, productMaxPrice, productCount, profitType, compactDisplay, secondsPerAction, chance);
         return `
-            <div class="${classId}-info-table" style="grid-template-columns: max-content repeat(${ingredientMinPrices.length + 2 + (productCount > 1) + (profitType !== "off")}, 1fr)">
+            <div class="${classId}-info-table ${classes}" style="grid-template-columns: max-content repeat(${ingredientMinPrices.length + 2 + (productCount > 1) + (profitType !== "off")}, 1fr)">
                 ${header}
                 ${Templates.infoTableCell(classId, compactDisplay ? "Min" : "Minimal Marketprice")}
                 ${minPrice}
@@ -161,7 +161,7 @@ static infoTableRow(classId, ingredientPrices, ingredientCounts, productPrice, p
 
     /**
      * Creates a notification with the provided message that disappears after 10 seconds or when the user clicks on it.
-     * 
+     *
      * @param {string} type options are `success` (green), `info` (blue), `warning` (yellow) and `danger` (red)
      * @param {string} title string
      * @param {string} message string
@@ -199,7 +199,7 @@ static infoTableRow(classId, ingredientPrices, ingredientCounts, productPrice, p
     /**
      * Creates a popup with the provided content that can be closed by clicking on the background.
      * The relevant css classes are defined in tracker.js.
-     * 
+     *
      * @param {string} content html string
      * @returns {string} html string
      */
@@ -213,10 +213,10 @@ static infoTableRow(classId, ingredientPrices, ingredientCounts, productPrice, p
 
     /**
      * Creates a select menu with the provided options.
-     * 
+     *
      * @param {string} id When saving settings the id gets split at all '-' and then saved in the settings menu at that position
-     *                    e.g. the selected value of the select menu with id "module-css-header" will be stored at 
-     *                    `this.settings.module.css.header`. The setting needs to be set to a default value in the constructor of 
+     *                    e.g. the selected value of the select menu with id "module-css-header" will be stored at
+     *                    `this.settings.module.css.header`. The setting needs to be set to a default value in the constructor of
      *                    the corresponding module if it's not set.
      *                    !! This will not check if the path exists in the settings !!
      * @param {Object} options object with pairs of the internal settingsname and a string for the display
@@ -267,8 +267,8 @@ static infoTableRow(classId, ingredientPrices, ingredientCounts, productPrice, p
      * Creates a template for a slider
      *
      * @param {string} id When saving settings the id gets split at all '-' and then saved in the settings menu at that position
-     *                    e.g. the selected value of the select menu with id "module-css-header" will be stored at 
-     *                    `this.settings.module.css.header`. The setting needs to be set to a default value in the constructor of 
+     *                    e.g. the selected value of the select menu with id "module-css-header" will be stored at
+     *                    `this.settings.module.css.header`. The setting needs to be set to a default value in the constructor of
      *                    the corresponding module if it's not set.
      *                    !! This will not check if the path exists in the settings !!
      * @param {Array} range minimum and maximum value of the slider, a third value can be provided to set the step size
@@ -282,7 +282,7 @@ static infoTableRow(classId, ingredientPrices, ingredientCounts, productPrice, p
 
     static timeDurationTemplate(id, value = "", classes = "") {
         const durationInput = document.createElement('input');
-        durationInput.id = id; 
+        durationInput.id = id;
         durationInput.classList = `tracker-time-duration ${classes}`;
         durationInput.type = 'text';
         durationInput.value = value;

--- a/tracker.js
+++ b/tracker.js
@@ -360,7 +360,6 @@ input[type="time"].tracker-time:not(.browser-default) {
 
         this.storage = new Storage(() => this.onApiUpdate());
 
-        window.addEventListener("beforeunload", () => this.storage.handleClose());
         document.addEventListener("keydown", (event) => {
             if (event.key === "Escape") {
                 this.closePopup();

--- a/tracker.js
+++ b/tracker.js
@@ -11,11 +11,7 @@ class Tracker {
     width: 100%;
 }
 
-.drawer-item {
-    justify-content: space-between;
-}
-
-.drawer-item-left {
+.tracker-drawer-item-left {
     width: 100%;
 }
 
@@ -444,13 +440,16 @@ input[type="time"].tracker-time:not(.browser-default) {
         oldSidebarItem?.remove();
 
         const vanillaSettings = document.getElementsByClassName("Settings")[0];
-        vanillaSettings.insertAdjacentHTML("afterend", `
+        vanillaSettings.insertAdjacentHTML(
+            "afterend",
+            `
             <div id="tracker-settings-sidebar" class="drawer-item active noselect tracker">
-                <div class="drawer-item-left">
+                <div class="drawer-item-left tracker-drawer-item-left">
                     ${Templates.trackerLogoTemplate("drawer-item-icon")}
                     Marketplace Tracker
                 </div>
-            </div>`);
+            </div>`
+        );
         document.getElementById("tracker-settings-sidebar").addEventListener("click", () => {
             // Hide sidebar unless it's pinned
             if (!document.getElementsByClassName("drawer-item center")[0].lastChild.classList.contains("pressed")) {
@@ -472,13 +471,16 @@ input[type="time"].tracker-time:not(.browser-default) {
             navTabContainer.style.display = "none";
         }
 
-        navTabContainer.insertAdjacentHTML("afterend", `
+        navTabContainer.insertAdjacentHTML(
+            "afterend",
+            `
             <div id="tracker-settings-nav-tab-container" class="tracker-nav-tab-container">
                 <div class="nav-tab noselect selected-tab tracker">
                     ${Templates.trackerLogoTemplate("nav-tab-icon icon-border")}
                     Tracker
                 </div>
-            </div>`);
+            </div>`
+        );
         const selectedSkill = getSelectedSkill();
 
         const playAreaBackground = playAreaContainer.getElementsByClassName("play-area-background")[0];
@@ -520,7 +522,10 @@ input[type="time"].tracker-time:not(.browser-default) {
             }
             const moduleSettings = document.createElement("div");
             moduleSettings.className = "settings-module";
-            saveInsertAdjacentHTML(moduleSettings, "beforeend", `
+            saveInsertAdjacentHTML(
+                moduleSettings,
+                "beforeend",
+                `
                 <div class="settings-module-header">
                     <div class="settings-module-header-toggle-icon">
                         ${module.icon}
@@ -529,14 +534,17 @@ input[type="time"].tracker-time:not(.browser-default) {
                         ${module.displayName}
                     </div>
                     ${Templates.checkboxTemplate(moduleId, this.settings.activeModules[moduleId])}
-                </div>`);
+                </div>`
+            );
             const moduleSettingsContent = document.createElement("div");
             moduleSettingsContent.className = "settings-module-content";
             this.addModuleSettings(moduleId, moduleSettingsContent);
             moduleSettings.append(moduleSettingsContent);
             settingCategories[module.category].div.append(moduleSettings);
         }
-        settingsArea.insertAdjacentHTML("beforeend", `
+        settingsArea.insertAdjacentHTML(
+            "beforeend",
+            `
             <div class="settings-footer">
                 <div id="settings-reset" class="tracker-settings-button idlescape-button-red">
                     Reset
@@ -552,7 +560,8 @@ input[type="time"].tracker-time:not(.browser-default) {
                 <div id="settings-save" class="tracker-settings-button idlescape-button-green">
                     Save
                 </div>
-            </div>`);
+            </div>`
+        );
         playAreaBackground.append(settingsArea);
 
         this.warningShown = false;
@@ -617,7 +626,10 @@ input[type="time"].tracker-time:not(.browser-default) {
     }
 
     importExportPopup() {
-        saveInsertAdjacentHTML(document.body, "beforeend", Templates.popupTemplate(`
+        saveInsertAdjacentHTML(
+            document.body,
+            "beforeend",
+            Templates.popupTemplate(`
             <div class="import-export-popup">
                 <div class="import-export-popup-title">
                     Import/Export
@@ -672,7 +684,8 @@ input[type="time"].tracker-time:not(.browser-default) {
                         Close
                     </div>
                 </div>
-            </div>`));
+            </div>`)
+        );
         document.getElementById("tracker-import-settings").addEventListener("click", () => this.importSettings());
         document.getElementById("tracker-export-settings").addEventListener("click", () => this.exportSettings());
         document.getElementById("tracker-import-market").addEventListener("click", () => this.importStorage());


### PR DESCRIPTION
- crafting tracker is functional again
- all modules use `onAPIUpdate` to update displayed prices instantly when an API call hits in the background
  - e.g. the quantiles colors update while on the page, user doesn't need switch tab and back
- fix for prices gettings stored twice or more in itemList
- below vendor warning is correct even when updating a listing
- API calls are synced to the API update schedule, every 10 minutes
- fixed weird sidebar level spacing
  - ISMonkey uses the same css, so the issue might still be there, if their script is active aswell
- prevent infinite observer loops, causing crashes
- multiple items with the same item image now either give no value or modules can provide the name of the item as a fallback option
- fix smithing tracker using the wrong heat value based on localization