### PR TITLE
v1.3.16

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Idlescape Marketplace Tracker",
-    "version": "1.3.15",
+    "version": "1.3.16",
     "description": "Automatically tracks prices of items on the Idlescape Marketplace",
     "content_scripts": [
         {

--- a/marketplace_tracker.user.js
+++ b/marketplace_tracker.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Idlescape Marketplace Tracker
 // @namespace    https://github.com/IceFreez3r
-// @version      1.3.15
+// @version      1.3.16
 // @description  Automatically tracks prices of items on the Idlescape Marketplace
 // @author       IceFreez3r
 // @match        https://www.play.idlescape.com/*

--- a/modules/cooking.js
+++ b/modules/cooking.js
@@ -42,6 +42,16 @@ class CookingTracker {
     object-fit: contain;
 }
 
+.cooking-prep-table-price {
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+}
+
+.cooking-prep-table-relative-price {
+    font-size: 0.8em;
+}
+
 .anchor-cooking-content {
     flex-direction: column;
     flex-wrap: unset;
@@ -213,7 +223,7 @@ class CookingTracker {
     }
 
     preparationTracker(forceUpdate = false) {
-        const oldTable = document.querySelector(".cooking-prep-table");
+        const oldTable = document.querySelector(".cooking-prep-table-container");
         if (!forceUpdate && oldTable) {
             return;
         }
@@ -260,7 +270,9 @@ class CookingTracker {
     preparationTable() {
         const itemObject = getIdlescapeWindowObject().items;
         const cookingData = getIdlescapeWindowObject().cooking;
-        const preparedApiIds = Object.keys(cookingData).filter((apiId) => cookingData[apiId].prepared);
+        const preparedApiIds = Object.keys(cookingData).filter(
+            (apiId) => cookingData[apiId].prepared && itemObject[apiId].tradeable
+        );
         const allIngredientApiIds = Object.keys(cookingData).filter((apiId) => !cookingData[apiId].prepared);
         const ingredientPriceData = this.storage.analyzeItems(allIngredientApiIds);
         const inputData = preparedApiIds.map((apiId) => {
@@ -367,7 +379,12 @@ class CookingTracker {
                     ${
                         fields["min"]
                             ? `<div class="cooking-prep-table-content">
-                        ${formatNumber(columnData.prices.minPrice)}
+                        <div class="cooking-prep-table-price">
+                            <div>${formatNumber(columnData.prices.minPrice)}</div>
+                            <div class="cooking-prep-table-relative-price">(${formatNumber(
+                                columnData.prices.minPrice / columnData.size
+                            )})</div>
+                        </div>
                         ${columns[column].includes("min") ? Templates.dotTemplate("1em", "", "rgb(0, 255, 0)") : ""}
                     </div>`
                             : ""
@@ -375,7 +392,12 @@ class CookingTracker {
                     ${
                         fields["median"]
                             ? `<div class="cooking-prep-table-content">
-                        ${formatNumber(columnData.prices.medianPrice)}
+                        <div class="cooking-prep-table-price">
+                            <div>${formatNumber(columnData.prices.medianPrice)}</div>
+                            <div class="cooking-prep-table-relative-price">(${formatNumber(
+                                columnData.prices.medianPrice / columnData.size
+                            )})</div>
+                        </div>
                         ${columns[column].includes("median") ? Templates.dotTemplate("1em", "", "rgb(0, 255, 0)") : ""}
                     </div>`
                             : ""
@@ -383,7 +405,12 @@ class CookingTracker {
                     ${
                         fields["max"]
                             ? `<div class="cooking-prep-table-content">
-                        ${formatNumber(columnData.prices.maxPrice)}
+                        <div class="cooking-prep-table-price">
+                            <div>${formatNumber(columnData.prices.maxPrice)}</div>
+                            <div class="cooking-prep-table-relative-price">(${formatNumber(
+                                columnData.prices.maxPrice / columnData.size
+                            )})</div>
+                        </div>
                         ${columns[column].includes("max") ? Templates.dotTemplate("1em", "", "rgb(0, 255, 0)") : ""}
                     </div>`
                             : ""
@@ -401,7 +428,7 @@ class CookingTracker {
             return;
         }
         const productApiId = convertApiId(productNode.firstChild);
-        const augment = parseInt(productNode.querySelector(".item-augment")?.textContent.split("+")[1]);
+        const augment = parseInt(productNode.querySelector(".item-augment")?.textContent.split("+")[1] ?? 0);
         const buffSrc = productNode.querySelector(".anchor-item-enchant")?.src;
         const buffSrcShort = buffSrc ? buffSrc.split("/").pop() : null;
         if (


### PR DESCRIPTION
fixed crash on alchemy page due to NaN !== NaN
prep table shows relative prices below ingredient market prices based on the ingredients size
prep table removes the correct container, when it gets recomputed
removed untradeable prepped items from prep table (giant nails and cookie dough)
